### PR TITLE
Use alpine v3.14 in build

### DIFF
--- a/Dockerfile.esy
+++ b/Dockerfile.esy
@@ -16,7 +16,7 @@ RUN npm install -g --unsafe-perm $ESY_VERSION
 # now that we have esy installed we need a proper runtime
 # we should be able to use the esy install script in the future
 
-FROM alpine:3.9 as esy
+FROM alpine:3.14 as esy
 
 ENV TERM=dumb LD_LIBRARY_PATH=/usr/local/lib:/usr/lib:/lib
 


### PR DESCRIPTION
The current of alpine is 3.9, I think it's a good time to update now.
Old alpine versions doesn't contain packages that I need