### PR TITLE
Remove temp app to save space

### DIFF
--- a/Dockerfile.ocaml
+++ b/Dockerfile.ocaml
@@ -21,6 +21,4 @@ RUN echo ' \
 
 RUN cat esy.json
 
-RUN esy
-
-Run rm -rf /tmp/app
+RUN esy && rm -rf /tmp/app

--- a/Dockerfile.ocaml
+++ b/Dockerfile.ocaml
@@ -22,3 +22,5 @@ RUN echo ' \
 RUN cat esy.json
 
 RUN esy
+
+Run rm -rf /tmp/app


### PR DESCRIPTION
Since esy copy things from global cache to `.esy` . 
Removing the temporary app folder after installing ocaml compiler would save some space in the final docker image