### PR TITLE
Install tar in `esy` image

### DIFF
--- a/Dockerfile.esy
+++ b/Dockerfile.esy
@@ -25,7 +25,7 @@ WORKDIR /
 COPY --from=build /esy /esy
 
 RUN apk add --no-cache ca-certificates wget bash curl perl-utils git patch \
-    gcc g++ musl-dev make m4 linux-headers coreutils libstdc++
+    gcc g++ musl-dev make m4 linux-headers coreutils libstdc++ tar
 
 RUN wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub
 RUN wget https://github.com/sgerrand/alpine-pkg-glibc/releases/download/2.31-r0/glibc-2.31-r0.apk


### PR DESCRIPTION
This is because alpine's tar isn't GNU tar thus have troubles with some tar files. Especially those created on macOS.

Regression was introduced in #3